### PR TITLE
Add volume for integration layer logs

### DIFF
--- a/configuration/integration-layer/logging.json
+++ b/configuration/integration-layer/logging.json
@@ -1,0 +1,89 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "simple": {
+      "format": "[%(asctime)s.%(msecs)03d] [integration-layer] [%(levelname)s]\t %(message)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "level": "DEBUG",
+      "formatter": "simple",
+      "stream": "ext://sys.stdout"
+    },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "level": "DEBUG",
+      "formatter": "simple",
+      "filename": "log/fleet-management-integration-layer.log"
+    }
+  },
+  "loggers": {
+    "fleetman_integration.protocol.checker": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.layer": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.protocol.handler": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.protocol.api_adapter": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.management.checker": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.management.handler": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    },
+    "fleetman_integration.management.api_adapter": {
+      "level": "DEBUG",
+      "handlers": [
+        "console",
+        "file"
+      ],
+      "propagate": false
+    }
+  },
+  "root": {
+    "level": "DEBUG",
+    "handlers": [
+      "console",
+      "file"
+    ]
+  }
+}

--- a/configuration/integration-layer/logging.json
+++ b/configuration/integration-layer/logging.json
@@ -18,7 +18,7 @@
       "class": "logging.handlers.RotatingFileHandler",
       "level": "DEBUG",
       "formatter": "simple",
-      "filename": "log/fleet-management-integration-layer.log"
+      "filename": "/usr/src/app/log/fleet-management-integration-layer.log"
     }
   },
   "loggers": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,11 +90,10 @@ services:
     networks:
       - bring-emulator
     volumes:
-      - ./configuration/integration-layer/config.json:/usr/src/app/config.json
-      - ./configuration/integration-layer/logging.json:/usr/src/app/logging.json
+      - ./configuration/integration-layer:/usr/src/app/config
       - ./docker_volumes/integration-layer:/usr/src/app/log
     entrypoint:
-      ["python3", "-m", "fleetman_integration", "config.json"]
+      ["python3", "-m", "fleetman_integration", "config/config.json"]
 
   management-api:
     image: bringauto/fleet-management-http-api:v3.1.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
       - bring-emulator
     volumes:
       - ./configuration/integration-layer/config.json:/usr/src/app/config.json
+      - ./configuration/integration-layer/logging.json:/usr/src/app/logging.json
+      - ./docker_volumes/integration-layer:/usr/src/app/log
     entrypoint:
       ["python3", "-m", "fleetman_integration", "config.json"]
 

--- a/docker_volumes/integration-layer/.gitignore
+++ b/docker_volumes/integration-layer/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The integration layer produces a log file, that can be accessed in etna. 

A configuration file for logging (logging.json) was added to the configuration/integration-layer folder. 

