### PR TITLE
Baf 904/add docker profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ Docker compose file has multiple profiles so the developer can disable/enable pa
 - mqtt - start only MQTT vernemq broker
 - module-gateway - start only Module Gateway
 - http-api - start fleet protocol HTTP API server and the related PostgreSQL database
-- for-virtual-fleet - start fleet protocol HTTP API server, the related PostgreSQL database, fleet management integration layer, fleet management HTTP API server and mission module display tool
+- for-virtual-fleet - start fleet protocol HTTP API server, the related PostgreSQL database, fleet management integration layer, virtual fleet management, fleet management HTTP API server and mission module display tool
 
 Now you can run `docker compose --profile <profile> up` where `profile` is the name of the profile above.
 
-To run components with different arguments you can edit the configuration files placed under configuration/<component>
+To run components with different arguments you can edit the configuration files placed under `configuration/<component_name>/` where `component_name` is the name of the component.
 
 ### HTTP API
 
-To show the OpenAPI specification (the service must be running), visit http://localhost:8080/v2/protocol/openapi.json.
-To explore the API endpoints and entities, visit http://localhost:8080/v2/protocol/ui. More on Swagger UI
+To show the OpenAPI specification (the service must be running), visit [http://localhost:8080/v2/protocol/openapi.json](http://localhost:8080/v2/protocol/openapi.json).
+To explore the API endpoints and entities, visit [http://localhost:8080/v2/protocol/ui](http://localhost:8080/v2/protocol/ui). More on Swagger UI
 is [here](https://swagger.io/tools/swagger-ui/).
 
 The HTTP API requires authentication via API keys. To access all its endpoints, you can use the
@@ -77,8 +77,8 @@ overwrites the original config from the http-api image).
 
 ### Fleet Management API
 
-To show the OpenAPI specification (the service must be running), visit http://localhost:8081/v2/management/openapi.json.
-To explore the API endpoints and entities, visit http://localhost:8081/v2/management/ui. More on Swagger UI
+To show the OpenAPI specification (the service must be running), visit [http://localhost:8081/v2/management/openapi.json](http://localhost:8081/v2/management/openapi.json).
+To explore the API endpoints and entities, visit [http://localhost:8081/v2/management/ui](http://localhost:8081/v2/management/ui). More on Swagger UI
 is [here](https://swagger.io/tools/swagger-ui/).
 
 The Fleet Management API requires authentication via API keys. To access all its endpoints, you can use the
@@ -93,6 +93,7 @@ image).
 Simulates the Fleet Management ([documentation](https://github.com/bringauto/virtual-fleet-management/blob/main/README.md).
 
 The Virtual Fleet Management uses `env` variables to set:
+
 - **ETNA_VFM_SCENARIO** : Changes the scenario that the Virtual Fleet Management will use.
 - **ETNA_VFM_CONFIG** : Changes the configuration of the Virtual Fleet Management.
 
@@ -106,18 +107,17 @@ The Mission Module Display Tool runs a simple web server to display the position
 ### Common Issues
 
 - external-server and module-gateway connect sequence
-    - mqtt tends to be unstable in some cases, which could lead to problems in ES and MG communication. Consider
+- mqtt tends to be unstable in some cases, which could lead to problems in ES and MG communication. Consider
       changing the mqtt_timeout in ES config if there are connection problems (numbers greater than 15 and no multiples
       of 15 should be used)
-- postgresql databases
-    - databases are created only on container creation (if you have an old container, it needs to be deleted)
+postgresql databases - are created only on container creation (if you have an old container, it needs to be deleted)
 - http APIs
-    - by default API containers wait for the postgresql database to be available. If the database fails to initialize,
+- by default API containers wait for the postgresql database to be available. If the database fails to initialize,
       the containers won't start
 
 ## MQTT IP and Port
 
-The MQTT uses a standard plain (not encrypted) connection on port 1883 and an SSL encrypted connection on port 8883.
+The MQTT uses a standard plain (not encrypted) connection on port 1883 and an SSL-encrypted connection on port 8883.
 
 There are [pregenerated certificate files] for both, server and client, however, it is not recommended to use those, and
 they are there for Etna to work out-of-box.
@@ -130,7 +130,7 @@ paths in file `configuration/mosquitto/mosquitto.conf`.
 
 ## Topics to listen
 
-Each MQTT topic consist from `company_name` and `car_name`.
+Each MQTT topic consists of `company_name` and `car_name`.
 
 BringAuto has the following MQTT topics
 
@@ -153,7 +153,7 @@ Logs for each component can be found in the `docker_volumes` directory.
 > The component directories are pre-created in the repository to avoid permission problems associated with docker
 > volumes.
 
-In case of a problem please attach the `docker_volumes` directory to the Bug report.
+In case of a problem, please attach the `docker_volumes` directory to the Bug report.
 
 ## Example scripts
 
@@ -161,16 +161,16 @@ There are example scripts for sniffing communication and seeing the basics [scri
 
 ## Bug solving
 
-Docker container can have error similar to this: 
-```
+Docker container can have error similar to this:
+
+``` log
 Error: Invalid require_certificate value (false
 Error found at /mosquitto/config/mosquitto.conf:2.
 ```
+
 If this happens, make sure the mentioned file uses LF line ending. (CRLF doesn't work)
 
 [Fleet]: https://github.com/bringauto/fleet
-
-[Google Artifacts Registry]: https://console.cloud.google.com/artifacts/docker/bringauto-infrastructure/europe-west1/virtual-platform?hl=cs&project=bringauto-infrastructure
 
 [pregenerated certificate files]: configuration/mosquitto/certs
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Docker compose file has multiple profiles so the developer can disable/enable pa
 - mqtt - start only MQTT vernemq broker
 - module-gateway - start only Module Gateway
 - http-api - start fleet protocol HTTP API server and the related PostgreSQL database
-- for-virtual-fleet - start fleet protocol HTTP API server, the related PostgreSQL database, fleet management integration layer and fleet management HTTP API server
+- for-virtual-fleet - start fleet protocol HTTP API server, the related PostgreSQL database, fleet management integration layer, fleet management HTTP API server and mission module display tool
 
 Now you can run `docker compose --profile <profile> up` where `profile` is the name of the profile above.
 
@@ -98,6 +98,10 @@ The Virtual Fleet Management uses `env` variables to set:
 
 All the scenarios and configurations must be stored in the `configuration/virtual-fleet-management` directory, so the docker container has access to it.
 Both variables have default values, so the Virtual Fleet Management can be started without setting them.
+
+### Mission module display tool
+
+The Mission Module Display Tool runs a simple web server to display the positions of vehicles on a map. By default, the server is available at `http://localhost:5000`. It utilizes the fleet protocol HTTP API to retrieve vehicle positions. Comprehensive documentation can be found [here](https://github.com/bringauto/mission-module-display-tool/blob/main/README.md).
 
 ### Common Issues
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Docker compose file has multiple profiles so the developer can disable/enable pa
 - virtual-plc - start only Virtual PLC
 - mqtt - start only MQTT vernemq broker
 - module-gateway - start only Module Gateway
-- http-api - start HTTP API server and the related PostgreSQL database
+- http-api - start fleet protocol HTTP API server and the related PostgreSQL database
+- for-virtual-fleet - start fleet protocol HTTP API server, the related PostgreSQL database, fleet management integration layer and fleet management HTTP API server
 
 Now you can run `docker compose --profile <profile> up` where `profile` is the name of the profile above.
 

--- a/configuration/mission-module-display-tool/config.json
+++ b/configuration/mission-module-display-tool/config.json
@@ -1,0 +1,5 @@
+{
+    "api-url": "http://http-api:8080/v2/protocol",
+    "api-key": "ProtocolStaticAccessKey",
+    "port": 5000
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_1/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_1/scenario1.json
@@ -1,0 +1,177 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 1,
+      "name": "mission1",
+      "stops": [
+        {
+          "name": "Svatopluka Čecha A"
+        }
+      ],
+      "route": "Moravské náměstí 2"
+    },
+    {
+      "delay_seconds": 2,
+      "name": "mission2",
+      "stops": [
+        {
+          "name": "Charvatská A"
+        },
+        {
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "name": "Slovinská"
+        },
+        {
+          "name": "Bulharská"
+        }
+      ],
+      "route": "Roundabout long"
+    },
+    {
+      "delay_seconds": 3,
+      "name": "mission3",
+      "stops": [
+        {
+          "name": "Těšínská"
+        },
+        {
+          "name": "Vodova"
+        }
+      ],
+      "route": "Moravské naměstí 1"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_1/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_1/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 1,
+      "delay_seconds": 0,
       "name": "mission1",
       "stops": [
         {
@@ -13,7 +13,7 @@
       "route": "Moravské náměstí 2"
     },
     {
-      "delay_seconds": 2,
+      "delay_seconds": 10,
       "name": "mission2",
       "stops": [
         {
@@ -32,7 +32,7 @@
       "route": "Roundabout long"
     },
     {
-      "delay_seconds": 3,
+      "delay_seconds": 20,
       "name": "mission3",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_2/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_2/scenario1.json
@@ -1,0 +1,164 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission1",
+      "stops": [
+        {
+          "name": "Svatopluka Čecha A"
+        }
+      ],
+      "route": "Moravské náměstí 2"
+    },
+    {
+      "delay_seconds": 0,
+      "name": "mission2",
+      "stops": [
+        {
+          "name": "Charvatská A"
+        },
+        {
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "name": "Slovinská"
+        },
+        {
+          "name": "Bulharská"
+        }
+      ],
+      "route": "Roundabout long"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_2/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_2/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission1",
       "stops": [
         {
@@ -13,7 +13,7 @@
       "route": "Moravské náměstí 2"
     },
     {
-      "delay_seconds": 0,
+      "delay_seconds": 30,
       "name": "mission2",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_3/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_3/scenario1.json
@@ -1,0 +1,158 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission1",
+      "stops": [
+        {
+          "name": "Svatopluka Čecha A"
+        }
+      ],
+      "route": "Moravské náměstí 2"
+    },
+    {
+      "delay_seconds": 0,
+      "name": "mission3",
+      "stops": [
+        {
+          "name": "Těšínská"
+        },
+        {
+          "name": "Vodova"
+        }
+      ],
+      "route": "Moravské naměstí 1"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_3/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_3/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission1",
       "stops": [
         {
@@ -13,7 +13,7 @@
       "route": "Moravské náměstí 2"
     },
     {
-      "delay_seconds": 0,
+      "delay_seconds": 20,
       "name": "mission3",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_4/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_4/scenario1.json
@@ -1,0 +1,167 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission2",
+      "stops": [
+        {
+          "name": "Charvatská A"
+        },
+        {
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "name": "Slovinská"
+        },
+        {
+          "name": "Bulharská"
+        }
+      ],
+      "route": "Roundabout long"
+    },
+    {
+      "delay_seconds": 0,
+      "name": "mission3",
+      "stops": [
+        {
+          "name": "Těšínská"
+        },
+        {
+          "name": "Vodova"
+        }
+      ],
+      "route": "Moravské naměstí 1"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_4/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_4/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 20,
       "name": "mission2",
       "stops": [
         {
@@ -22,7 +22,7 @@
       "route": "Roundabout long"
     },
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission3",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_5/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_5/scenario1.json
@@ -1,0 +1,145 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission1",
+      "stops": [
+        {
+          "name": "Svatopluka Čecha A"
+        }
+      ],
+      "route": "Moravské náměstí 2"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_5/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_5/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission1",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_6/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_6/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission3",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_6/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_6/scenario1.json
@@ -1,0 +1,148 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission3",
+      "stops": [
+        {
+          "name": "Těšínská"
+        },
+        {
+          "name": "Vodova"
+        }
+      ],
+      "route": "Moravské naměstí 1"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_7/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_7/scenario1.json
@@ -3,7 +3,7 @@
   "starting_station": "Těšínská",
   "missions": [
     {
-      "delay_seconds": 0,
+      "delay_seconds": 10,
       "name": "mission2",
       "stops": [
         {

--- a/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_7/scenario1.json
+++ b/configuration/virtual-fleet-management/scenarios/default/virtual_vehicle_7/scenario1.json
@@ -1,0 +1,154 @@
+{
+  "map": "map.osm",
+  "starting_station": "Těšínská",
+  "missions": [
+    {
+      "delay_seconds": 0,
+      "name": "mission2",
+      "stops": [
+        {
+          "name": "Charvatská A"
+        },
+        {
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "name": "Slovinská"
+        },
+        {
+          "name": "Bulharská"
+        }
+      ],
+      "route": "Roundabout long"
+    }
+  ],
+  "routes": [
+    {
+      "name": "Moravské náměstí 2",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.22293,
+            "longitude": 16.59185,
+            "altitude": 0
+          },
+          "name": "Charvatská B"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    },
+    {
+      "name": "Moravské naměstí 1",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2221382,
+            "longitude": 16.5875405,
+            "altitude": 0
+          },
+          "name": "Skácelova"
+        },
+        {
+          "position": {
+            "latitude": 49.2231615,
+            "longitude": 16.5868266,
+            "altitude": 0
+          },
+          "name": "Vodova"
+        },
+        {
+          "position": {
+            "latitude": 49.2244714,
+            "longitude": 16.5904498,
+            "altitude": 0
+          },
+          "name": "Srbská"
+        }
+      ]
+    },
+    {
+      "name": "Roundabout long",
+      "stations": [
+        {
+          "position": {
+            "latitude": 49.2231587,
+            "longitude": 16.5899511,
+            "altitude": 0
+          },
+          "name": "Těšínská"
+        },
+        {
+          "position": {
+            "latitude": 49.2216472,
+            "longitude": 16.5908117,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha A"
+        },
+        {
+          "position": {
+            "latitude": 49.2216654,
+            "longitude": 16.5917516,
+            "altitude": 0
+          },
+          "name": "Charvatská A"
+        },
+        {
+          "position": {
+            "latitude": 49.2219936,
+            "longitude": 16.5933439,
+            "altitude": 0
+          },
+          "name": "Svatopluka Čecha B"
+        },
+        {
+          "position": {
+            "latitude": 49.2233,
+            "longitude": 16.59265,
+            "altitude": 0
+          },
+          "name": "Slovinská"
+        },
+        {
+          "position": {
+            "latitude": 49.22382,
+            "longitude": 16.59239,
+            "altitude": 0
+          },
+          "name": "Bulharská"
+        }
+      ]
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   external-server:
     image: bringauto/external-server:v1.1.9
-    profiles: ["all", "without-devices", "without-module-gateway", "without-external-server", "without-fleet-management"]
+    profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management"]
     volumes:
       - ./docker_volumes/external-server:/home/bringauto/log
       - ./configuration/external-server:/home/bringauto/config/
@@ -115,7 +115,7 @@ services:
 
   virtual-fleet-management:
     image: bringauto/virtual-fleet-management:v3.0.1
-    profiles: ["all", "without-devices", "without-module-gateway"]
+    profiles: ["all", "without-devices", "without-module-gateway", "for-virtual-fleet"]
     restart: "no"
     depends_on:
       management-api:
@@ -146,6 +146,18 @@ services:
       - 5432:5432
     volumes:
       - ./db/insert_test_api_key.sh:/docker-entrypoint-initdb.d/insert_test_api_key.sh
+
+  mission_module_display_tool:
+    image: bringauto/mission-module-display-tool:v1.0.0
+    profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management", "for-virtual-fleet"]
+    restart: "no"
+    ports:
+      - 5000:5000
+    networks:
+      - bring-emulator
+    volumes:
+      - ./configuration/mission-module-display-tool/config.json:/mission-module-display-tool/config/config-docker.json
+    command: --config=config/config-docker.json
 
 networks:
   bring-emulator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
 
   http-api:
     image: bringauto/fleet-protocol-http-api:v2.4.2
-    profiles: ["all", "without-devices", "without-module-gateway", "http-api", "without-fleet-management"]
+    profiles: ["all", "without-devices", "without-module-gateway", "http-api", "without-fleet-management", "for-virtual-fleet"]
     ports:
       - 8080:8080
     restart: "no"
@@ -85,7 +85,7 @@ services:
 
   integration-layer:
     image: bringauto/fleet-management-integration-layer:v2.0.1
-    profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management"]
+    profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management", "for-virtual-fleet"]
     restart: "no"
     networks:
       - bring-emulator
@@ -97,7 +97,7 @@ services:
 
   management-api:
     image: bringauto/fleet-management-http-api:v3.1.6
-    profiles: ["all", "without-devices", "without-module-gateway", "management-api", "without-fleet-management"]
+    profiles: ["all", "without-devices", "without-module-gateway", "management-api", "without-fleet-management", "for-virtual-fleet"]
     ports:
       - 8081:8081
     restart: "no"
@@ -133,7 +133,7 @@ services:
 
   postgresql-database:
     image: postgres:16
-    profiles: ["all", "without-devices", "without-module-gateway", "http-api", "management-api", "without-fleet-management"]
+    profiles: ["all", "without-devices", "without-module-gateway", "http-api", "management-api", "without-fleet-management", "for-virtual-fleet"]
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: 1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
        "--location=postgresql-database"]
 
   integration-layer:
-    image: bringauto/fleet-management-integration-layer:v2.0.1
+    image: bringauto/fleet-management-integration-layer:v2.0.2
     profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management", "for-virtual-fleet"]
     restart: "no"
     networks:


### PR DESCRIPTION
This pull request adds a new docker profile specifically tailored to support virtual-fleet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new scenarios for virtual fleet management with detailed missions, routes, and stations.
  - Introduced a Mission Module Display Tool with comprehensive documentation.

- **Bug Fixes**
  - Improved URLs for OpenAPI specifications and API endpoints.
  - Clarified common issues and provided troubleshooting tips.

- **Documentation**
  - Updated README with new profiles, configuration instructions, and troubleshooting information.
  - Provided details on MQTT topics and certificate files for BringAuto.

- **Chores**
  - Updated Docker compose file to include new profiles and services for virtual fleet management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->