### PR TITLE
Update components

### DIFF
--- a/configuration/external-server/config.json
+++ b/configuration/external-server/config.json
@@ -1,25 +1,25 @@
 {
+  "logging": {
+    "log-path": "/home/bringauto/log/",
+    "verbose": true
+  },
   "company_name": "bringauto",
-  "car_name": "virtual_vehicle",
   "mqtt_address": "172.17.0.1",
   "mqtt_port": 1883,
   "mqtt_timeout": 20,
   "timeout": 20,
   "send_invalid_command": false,
   "sleep_duration_after_connection_refused": 0.5,
-  "log_files_directory": "/home/bringauto/log",
-  "log_files_to_keep": 5,
-  "log_file_max_size_bytes": 50000000,
-  "modules": {
+  "common_modules": {
     "1": {
       "lib_path": "/home/bringauto/modules/mission_module/lib/libmission-external-server-shared.so",
       "config": {
-          "api_url": "http://http-api:8080/v2/protocol",
-          "api_key": "ProtocolStaticAccessKey",
-          "max_requests_threshold_count": "5",
-          "max_requests_threshold_period_ms": "1000",
-          "delay_after_threshold_reached_ms": "500",
-          "retry_requests_delay_ms": "220"
+        "api_url": "http://http-api:8080/v2/protocol",
+        "api_key": "ProtocolStaticAccessKey",
+        "max_requests_threshold_count": "10",
+        "max_requests_threshold_period_ms": "5000",
+        "delay_after_threshold_reached_ms": "5000",
+        "retry_requests_delay_ms": "200"
       }
     },
     "2": {
@@ -27,11 +27,25 @@
       "config": {
         "api_url": "http://http-api:8080/v2/protocol",
         "api_key": "ProtocolStaticAccessKey",
-        "max_requests_threshold_count": "5",
-        "max_requests_threshold_period_ms": "1000",
-        "delay_after_threshold_reached_ms": "500",
-        "retry_requests_delay_ms": "220"
+        "max_requests_threshold_count": "10",
+        "max_requests_threshold_period_ms": "5000",
+        "delay_after_threshold_reached_ms": "5000",
+        "retry_requests_delay_ms": "200"
+      }
+    },
+    "3": {
+      "lib_path": "/home/bringauto/modules/transparent_module/lib/libtransparent-external-server-shared.so",
+      "config": {
+        "api_url": "http://http-api:8080/v2/protocol",
+        "api_key": "ProtocolStaticAccessKey",
+        "max_requests_threshold_count": "10",
+        "max_requests_threshold_period_ms": "5000",
+        "delay_after_threshold_reached_ms": "5000",
+        "retry_requests_delay_ms": "200"
       }
     }
+  },
+  "cars": {
+    "virtual_vehicle": {}
   }
 }

--- a/configuration/integration-layer/logging.json
+++ b/configuration/integration-layer/logging.json
@@ -18,7 +18,7 @@
       "class": "logging.handlers.RotatingFileHandler",
       "level": "DEBUG",
       "formatter": "simple",
-      "filename": "/usr/src/app/log/fleet-management-integration-layer.log"
+      "filename": "/home/bringauto/fleetman_integration/log/fleet-management-integration-layer.log"
     }
   },
   "loggers": {

--- a/configuration/module-gateway/config.json
+++ b/configuration/module-gateway/config.json
@@ -8,7 +8,8 @@
   },
   "module-paths": {
     "1": "/home/bringauto/modules/mission_module/lib/libmission-module-gateway-shared.so",
-    "2": "/home/bringauto/modules/io_module/lib/libio-module-gateway-shared.so"
+    "2": "/home/bringauto/modules/io_module/lib/libio-module-gateway-shared.so",
+    "3": "/home/bringauto/modules/transparent_module/lib/libtransparent-module-gateway-shared.so"
   },
   "external-connection" : {
     "company" : "bringauto",

--- a/configuration/virtual-vehicle-utility/config.json
+++ b/configuration/virtual-vehicle-utility/config.json
@@ -13,12 +13,18 @@
 				"rutx-port": 502,
 				"rutx-slave-id": 1
 			},
+			"map-settings": {
+				"map": "/virtual-vehicle-utility/config/map.osm",
+				"default-route": ""
+			},
 			"stop-radius-m": 8
 		},
 		"simulation-settings": {
 			"speed-override": true,
 			"speed-override-mps": 5,
-			"wait-at-stop-s": 10
+			"wait-at-stop-s": 10,
+			"map": "/virtual-vehicle-utility/config/map.osm",
+			"default-route": ""
 		}
 	},
 	"fleet-settings": {
@@ -33,10 +39,6 @@
 		},
 		"empty":{
 		}
-	},
-	"map-settings": {
-		"map": "/virtual-vehicle-utility/config/map.osm",
-		"default-route": ""
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   virtual-vehicle:
-    image: bringauto/virtual-vehicle:v3.2.0
+    image: bringauto/virtual-vehicle:v3.2.1
     profiles: ["all", "without-module-gateway", "without-external-server", "core", "virtual-vehicle", "without-fleet-management"]
     volumes:
       - ./docker_volumes/virtual-vehicle-utility:/virtual-vehicle-utility/log
@@ -31,7 +31,7 @@ services:
         condition: service_completed_successfully
 
   module-gateway:
-    image:  bringauto/module-gateway:v1.2.0
+    image:  bringauto/module-gateway:v1.2.1
     profiles: ["all", "without-devices", "without-external-server", "module-gateway", "core", "without-fleet-management"]
     volumes:
       - ./docker_volumes/module-gateway:/home/bringauto/log/
@@ -65,7 +65,7 @@ services:
         condition: service_completed_successfully
 
   external-server:
-    image: bringauto/external-server:v1.1.14
+    image: bringauto/external-server:v2.0.0
     profiles: ["all", "without-devices", "without-module-gateway", "without-fleet-management", "external_server", "cloud"]
     volumes:
       - ./docker_volumes/external-server:/home/bringauto/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   virtual-vehicle:
-    image: bringauto/virtual-vehicle:v3.1.7
+    image: bringauto/virtual-vehicle:v3.2.0
     profiles: ["all", "without-module-gateway", "without-external-server", "core", "virtual-vehicle", "without-fleet-management"]
     volumes:
       - ./docker_volumes/virtual-vehicle-utility:/virtual-vehicle-utility/log
@@ -97,16 +97,15 @@ services:
        "--location=postgresql-database"]
 
   integration-layer:
-    image: bringauto/fleet-management-integration-layer:v2.0.2
+    image: bringauto/fleet-management-integration-layer:v2.0.3
     profiles: ["all", "without-devices", "without-module-gateway", "without-external-server", "without-fleet-management", "for-virtual-fleet", "cloud"]
     restart: "no"
     networks:
       - bring-emulator
     volumes:
-      - ./configuration/integration-layer:/usr/src/app/config
-      - ./docker_volumes/integration-layer:/usr/src/app/log
-    entrypoint:
-      ["python3", "-m", "fleetman_integration", "config/config.json"]
+      - ./configuration/integration-layer:/home/bringauto/fleetman_integration/config
+      - ./docker_volumes/integration-layer:/home/bringauto/fleetman_integration/log
+    command: config/config.json
     depends_on:
       initialize-log-folders:
         condition: service_completed_successfully
@@ -188,7 +187,7 @@ services:
       - ./docker_volumes:/docker_volumes
     entrypoint: 
       ["/usr/bin/chown", "-R", "5000:5000", "/docker_volumes/module-gateway", "/docker_volumes/external-server",
-       "/docker_volumes/virtual-vehicle-utility"]
+       "/docker_volumes/virtual-vehicle-utility", "/docker_volumes/integration-layer"]
 
 networks:
   bring-emulator:

--- a/scripts/create_docker_compose_for_testing.py
+++ b/scripts/create_docker_compose_for_testing.py
@@ -98,7 +98,8 @@ def main():
                 return
             docker_compose['services'][component['name']]['image'] = f"{component['name']}:testing"
         replace_volumes(docker_compose, component, etna_path)
-        docker_compose['services'][component['name']]['profiles'].append(f"{component['name']}-testing")
+        if 'profiles' in docker_compose['services'][component['name']]:
+            docker_compose['services'][component['name']]['profiles'].append(f"{component['name']}-testing")
 
     with open(os.path.join(args.output, 'docker-compose.yml'), 'w') as file:
         yaml.indent(mapping=2, sequence=4, offset=2)


### PR DESCRIPTION
Updated:
- module gateway to v1.2.1
- external server to v2.0.0
- integration layer to v2.0.3

Virtual vehicle is set to v3.2.1, but is not yet available on that version. Closing this PR is required for integration tests of that version to pass.